### PR TITLE
no longer continue connecting loop when not live

### DIFF
--- a/application/lib/backend.dart
+++ b/application/lib/backend.dart
@@ -99,7 +99,7 @@ class CuddlyWorld extends ChangeNotifier {
         oldSocket = null;
       }
       Duration delay = const Duration(seconds: 2);
-      while (socket == null) {
+      while (socket == null && _live) {
         try {
           assert(_pendingResponses.isEmpty);
           _log('Connecting to $url...');


### PR DESCRIPTION
previously, `CuddlyWorld._loop` would continue trying to connect to a url even when it gets disposed.